### PR TITLE
Prepare for CI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,22 +41,22 @@ or add
 
 to your requirements file
 
-Once installed, you need to set `POST_OFFICE_URL`, `POST_OFFICE_CONSUMERS` and `POST_OFFICE_TIMEOUT` in your django settings file.
+Once installed, you need to set `POSTOFFICE_URL`, `POSTOFFICE_CONSUMERS` and `POSTOFFICE_TIMEOUT` in your django settings file.
 
-:POST_OFFICE_URL:
+:POSTOFFICE_URL:
    Is the `url` where server is hosted.
 
    .. code-block:: python
 
-      POST_OFFICE_URL = 'http://some_site.org/
+      POSTOFFICE_URL = 'http://some_site.org/
 
 
-:POST_OFFICE_CONSUMERS:
+:POSTOFFICE_CONSUMERS:
     Are the consumers which must been configured as publishers in postoffice server. With that, we create the necessary topics and publishers on postoffice
 
     .. code-block:: python
 
-       POST_OFFICE_CONSUMERS = [{
+       POSTOFFICE_CONSUMERS = [{
            'topic': 'some_topic',
            'endpoint': 'http://www.some_url.com',
            'type': 'http',
@@ -77,7 +77,7 @@ Once installed, you need to set `POST_OFFICE_URL`, `POST_OFFICE_CONSUMERS` and `
        http/pubsub
 
 
-:POST_OFFICE_TIMEOUT:
+:POSTOFFICE_TIMEOUT:
    Specific timeout to use on every communication with `postoffice`. If not specified the default value is 0.5 seconds.
 
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3'
+services:
+  db:
+    image: postgres:12.1
+    container_name: postoffice_django_db
+    environment:
+      - POSTGRES_PASSWORD=postoffice_django
+      - POSTGRES_USER=postoffice_django
+      - POSTGRES_DB=postoffice_django
+    ports:
+      - "6543:5432"

--- a/postoffice_django/config.py
+++ b/postoffice_django/config.py
@@ -29,7 +29,6 @@ def _create_publishers(consumer):
         'topic': consumer.get('topic'),
         'endpoint': consumer.get('endpoint'),
         'type': consumer.get('type'),
-        'initial_message': 0,
         'from_now': True
     }
 

--- a/postoffice_django/settings.py
+++ b/postoffice_django/settings.py
@@ -28,5 +28,6 @@ def get_timeout() -> Decimal:
     try:
         return settings.POSTOFFICE_TIMEOUT
     except AttributeError:
-        logger.info(f'Timeout not defined, using default value: {DEFAULT_TIMEOUT} (s)')
+        logger.info(
+            f'Timeout not defined, using default value: {DEFAULT_TIMEOUT} (s)')
         return DEFAULT_TIMEOUT

--- a/postoffice_django/settings.py
+++ b/postoffice_django/settings.py
@@ -12,21 +12,21 @@ DEFAULT_TIMEOUT = 0.5
 
 def get_url() -> str:
     try:
-        return settings.POST_OFFICE_URL
+        return settings.POSTOFFICE_URL
     except AttributeError:
         raise UrlSettingNotDefined
 
 
 def get_consumers() -> str:
     try:
-        return settings.POST_OFFICE_CONSUMERS
+        return settings.POSTOFFICE_CONSUMERS
     except AttributeError:
         raise ConsumersSettingNotDefined
 
 
 def get_timeout() -> Decimal:
     try:
-        return settings.POST_OFFICE_TIMEOUT
+        return settings.POSTOFFICE_TIMEOUT
     except AttributeError:
         logger.info(f'Timeout not defined, using default value: {DEFAULT_TIMEOUT} (s)')
         return DEFAULT_TIMEOUT

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,0 +1,2 @@
+django
+psycopg2-binary

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,0 +1,11 @@
+-r base.txt
+
+flake8>=2.1.0
+pytest>=4.6.0
+coverage>=4.4.0
+pytest-cov>=2.7.0
+pytest-django==3.8.0
+codecov>=2.0.0
+pytest-sugar==0.9.2
+responses==0.10.9
+pytest-responses==0.4.0

--- a/runtests.py
+++ b/runtests.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+# -*- coding: utf-8
+from __future__ import unicode_literals, absolute_import
+
+import os
+import sys
+
+import django
+from unittest.mock import patch
+
+
+class PytestTestRunner(object):
+    """Runs pytest to discover and run tests."""
+
+    def __init__(self, verbosity=1, failfast=False, keepdb=False, **kwargs):
+        self.verbosity = verbosity
+        self.failfast = failfast
+        self.keepdb = keepdb
+
+    def run_tests(self, test_labels):
+        """Run pytest and return the exitcode.
+
+        It translates some of Django's test command option to pytest's.
+        """
+        import pytest
+
+        argv = []
+        if self.verbosity == 0:
+            argv.append('--quiet')
+        if self.verbosity == 2:
+            argv.append('--verbose')
+        if self.verbosity == 3:
+            argv.append('-vv')
+        if self.failfast:
+            argv.append('--exitfirst')
+        if self.keepdb:
+            argv.append('--reuse-db')
+
+        argv.extend(test_labels)
+        return pytest.main(argv)
+
+
+def run_tests(*test_args):
+    if not test_args:
+        test_args = ['tests']
+
+    os.environ['DJANGO_SETTINGS_MODULE'] = 'tests.settings'
+
+    test_runner = PytestTestRunner()
+    failures = test_runner.run_tests(test_args)
+    sys.exit(bool(failures))
+
+
+if __name__ == '__main__':
+    run_tests(*sys.argv[1:])

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,24 @@
+[wheel]
+universal = 1
+
+[flake8]
+exclude=
+    __pycache__,
+    .git,
+    build,
+    dist,
+    *migrations
+ignore=D1,D401
+max-line-length=79
+max-complexity=10
+
+[isort]
+line_length=79
+default_section=THIRDPARTY
+known_first_party=postoffice_django
+multi_line_output=3
+use_parentheses=true
+
+[coverage:run]
+include=*
+omit=*/__init__.py

--- a/setup.py
+++ b/setup.py
@@ -10,20 +10,15 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name = 'postoffice_django',
-    version = '0.1',
-    description = 'Postoffice django client',
-    long_description = README,
-    author = 'MercadonaTech',
-    author_email = 'software.online@mercadona.es',
-    url = 'http://github.com/mercadona/postoffice_django',
+    version = '0.1.0',
     packages=find_packages(exclude=("tests",)),
     include_package_data = True,
-    install_requires=[
-        'django',
-        'requests'
-    ]
-    license='Apache Software License 2.0',
-    keywords='postoffice'
+    license = 'APACHE License',
+    description = 'A simple Django app to comunicate with post office',
+    long_description = README,
+    url = 'http://www.example.com/',
+    author = 'Your Name',
+    author_email = 'yourname@example.com',
     classifiers = [
         'Environment :: Web Environment',
         'Framework :: Django :: 2.0',

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,0 +1,43 @@
+SECRET_KEY = 'psst'
+
+DEBUG = True
+USE_TZ = True
+
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql',
+        'NAME': 'postoffice_django',
+        'USER': 'postoffice_django',
+        'PASSWORD': 'postoffice_django',
+        'HOST': 'localhost',
+        'PORT': '6543'
+    },
+}
+
+INSTALLED_APPS = (
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sites',
+    'postoffice_django'
+)
+
+AUTHENTICATION_BACKENDS = (
+    "django.contrib.auth.backends.ModelBackend",
+    "allauth.account.auth_backends.AuthenticationBackend",
+)
+
+POSTOFFICE_URL = 'http://fake.service'
+POSTOFFICE_CONSUMERS = [{
+    'topic': 'some_topic',
+    'endpoint': 'http://www.some_url.com',
+    'type': 'http',
+    'from_now': True
+  },
+  {
+    'topic': 'another_topic',
+    'endpoint': 'http://www.another_url.com',
+    'type': 'pubsub',
+    'from_now': False
+  }]
+POSTOFFICE_TIMEOUT = 0.3

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -54,14 +54,12 @@ class TestConfig:
             'endpoint': 'http://www.some_url.com',
             'topic': 'some_topic',
             'type': 'http',
-            'initial_message': 0,
             'from_now': True
         }
         assert json.loads(responses.calls[3].request.body) == {
             'active': True,
             'endpoint': 'http://www.another_url.com',
             'topic': 'another_topic',
-            'type': 'http',
-            'initial_message': 0,
+            'type': 'pubsub',
             'from_now': True
         }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,47 +4,32 @@ import os
 import pytest
 import responses
 
+from django.conf import settings
+
 from postoffice_django.config import configure
 
-POST_OFFICE_URL = os.environ.get('POST_OFFICE_URL', 'http://post_office_url')
+POSTOFFICE_URL = settings.POSTOFFICE_URL
 
 
 @pytest.mark.django_db
 class TestConfig:
-    POST_OFFICE_TOPIC_CREATION_URL = f'{POST_OFFICE_URL}/api/topics/'
-    POST_OFFICE_PUBLISHER_CREATION_URL = f'{POST_OFFICE_URL}/api/publishers/'
+    POSTOFFICE_TOPIC_CREATION_URL = f'{POSTOFFICE_URL}/api/topics/'
+    POSTOFFICE_PUBLISHER_CREATION_URL = f'{POSTOFFICE_URL}/api/publishers/'
 
-    @pytest.fixture
-    def consumers(self):
-        return [
-            {
-                'topic': 'some_topic',
-                'endpoint': 'http://www.some_url.com',
-                'type': 'http'
-            },
-            {
-                'topic': 'another_topic',
-                'endpoint': 'http://www.another_url.com',
-                'type': 'http'
-            }
-        ]
-
-    def test_create_topics_and_publishers(self, settings, consumers):
-        settings.POST_OFFICE_CONSUMERS = consumers
-        responses.add(responses.POST, self.POST_OFFICE_TOPIC_CREATION_URL, status=201,
+    def test_create_topics_and_publishers(self, settings):
+        responses.add(responses.POST, self.POSTOFFICE_TOPIC_CREATION_URL, status=201,
                       body="", content_type='application/json')
-        responses.add(responses.POST, self.POST_OFFICE_PUBLISHER_CREATION_URL, status=201,
+        responses.add(responses.POST, self.POSTOFFICE_PUBLISHER_CREATION_URL, status=201,
                       body="", content_type='application/json')
 
         configure()
 
         assert len(responses.calls) == 4
 
-    def test_request_body_sent_to_create_topic(self, settings, consumers):
-        settings.POST_OFFICE_CONSUMERS = consumers
-        responses.add(responses.POST, self.POST_OFFICE_TOPIC_CREATION_URL, status=201,
+    def test_request_body_sent_to_create_topic(self, settings):
+        responses.add(responses.POST, self.POSTOFFICE_TOPIC_CREATION_URL, status=201,
                       body="", content_type='application/json')
-        responses.add(responses.POST, self.POST_OFFICE_PUBLISHER_CREATION_URL, status=201,
+        responses.add(responses.POST, self.POSTOFFICE_PUBLISHER_CREATION_URL, status=201,
                       body="", content_type='application/json')
 
         configure()
@@ -56,11 +41,10 @@ class TestConfig:
             'name': 'another_topic'
         }
 
-    def test_request_body_sent_to_create_publishers(self, settings, consumers):
-        settings.POST_OFFICE_CONSUMERS = consumers
-        responses.add(responses.POST, self.POST_OFFICE_TOPIC_CREATION_URL, status=201,
+    def test_request_body_sent_to_create_publishers(self, settings):
+        responses.add(responses.POST, self.POSTOFFICE_TOPIC_CREATION_URL, status=201,
                       body="", content_type='application/json')
-        responses.add(responses.POST, self.POST_OFFICE_PUBLISHER_CREATION_URL, status=201,
+        responses.add(responses.POST, self.POSTOFFICE_PUBLISHER_CREATION_URL, status=201,
                       body="", content_type='application/json')
 
         configure()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -7,18 +7,18 @@ from postoffice_django.settings import get_consumers, get_timeout, get_url
 
 class SettingsTest:
     def test_raise_exception_when_post_office_url_is_not_defined(self, settings):
-        del(settings.POST_OFFICE_URL)
+        del(settings.POSTOFFICE_URL)
 
         with pytest.raises(UrlSettingNotDefined):
             get_url()
 
     def test_raise_exception_when_post_office_consumers_is_not_defined(self, settings):
-        del(settings.POST_OFFICE_CONSUMERS)
+        del(settings.POSTOFFICE_CONSUMERS)
 
         with pytest.raises(ConsumersSettingNotDefined):
             get_consumers()
 
     def test_returns_default_timeout_value_when_is_not_defined(self, settings):
-        del(settings.POST_OFFICE_TIMEOUT)
+        del(settings.POSTOFFICE_TIMEOUT)
 
         assert 0.5 == get_timeout()


### PR DESCRIPTION
A few things added/updated in order to be ready for CI! :) 
* Rename config keys, from `POST_OFFICE_*` to `POSTOFFICE_*`
* Add requirements
* Add test runner
* Postgresql container to be able to run tests locally
* Change body sent on publishers creation as `initial_message` is an internal value on postoffice