### PR TITLE
Continuous delivery to PyPi on git tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,9 +42,9 @@ jobs:
     steps:
       - checkout
       - run:
-        name: Install dependencies
-        command: |
-          pip install twine
+          name: Install dependencies
+          command: |
+            pip install twine
       - run:
           name: Verify git tag vs. version
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
       - run:
           name: Run test matrix
           command: |
-            tox -vv --parallel all
+            tox -vv
       - run:
           name: Test coverage
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,5 +11,11 @@ jobs:
         command: -p 6543
     steps:
       - checkout
-      - run: pip install tox
-      - run: tox --parallel all
+      - run:
+        name: Intall tox
+        command: |
+          pip install tox
+      - run:
+        name: Run test matrix
+        command: |
+          tox -v --parallel all

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
       - run:
           name: Run test matrix
           command: |
-            tox -v --parallel all
+            tox -vv --parallel all
       - run:
           name: Test coverage
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,3 +19,7 @@ jobs:
           name: Run test matrix
           command: |
             tox -v --parallel all
+      - run:
+          name: Test coverage
+          command: |
+            codecov -e TOXENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,14 +14,43 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            pip install tox codecov
+            pip install tox
       - run:
           name: Run test matrix
           command: |
-            tox -vv
+            tox -vv --parallel all
       - run:
-          name: Test coverage
+          name: Verify git tag vs. version
           command: |
-            coverage combine
-            coverage xml
-            codecov -e TOXENV
+            python setup.py verify
+      - run:
+          name: Init .pypirc
+          command: |
+            echo -e "[pypi]" >> ~/.pypirc
+            echo -e "username = $PYPI_USER" >> ~/.pypirc
+            echo -e "password = $PYPI_PASSWORD" >> ~/.pypirc
+      - run:
+          name: Create packages
+          command: |
+            python setup.py sdist
+            python setup.py bdist_wheel
+      - run:
+          name: Upload to pypi
+          command: |
+            twine upload dist/*
+workflows:
+  version: 2
+  build_and_deploy:
+    jobs:
+      - build:
+          filters:
+            tags:
+              only: /.*/
+      - deploy:
+          requires:
+            - build
+          filters:
+            tags:
+              only: /[0-9]+(\.[0-9]+)*/
+            branches:
+              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,9 +12,9 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Intall tox
+          name: Install dependencies
           command: |
-            pip install tox
+            pip install tox codecov
       - run:
           name: Run test matrix
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
       - run:
           name: Run test matrix
           command: |
-            tox -vv
+            tox -vv --parallel all
       - run:
           name: Test coverage
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,10 +12,10 @@ jobs:
     steps:
       - checkout
       - run:
-        name: Intall tox
-        command: |
-          pip install tox
+          name: Intall tox
+          command: |
+            pip install tox
       - run:
-        name: Run test matrix
-        command: |
-          tox -v --parallel all
+          name: Run test matrix
+          command: |
+            tox -v --parallel all

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,21 @@
-version: 2
+version: 2.1
+workflows:
+  version: 2
+  build_and_deploy:
+    jobs:
+      - build:
+          filters:
+            tags:
+              only: /.*/
+      - deploy:
+          requires:
+            - build
+          filters:
+            tags:
+              only: /[0-9]+(\.[0-9]+)*/
+            branches:
+              ignore: /.*/
+
 jobs:
   build:
     docker:
@@ -19,6 +36,15 @@ jobs:
           name: Run test matrix
           command: |
             tox -vv --parallel all
+  deploy:
+    docker:
+      - image: circleci/python:3.8
+    steps:
+      - checkout
+      - run:
+        name: Install dependencies
+        command: |
+          pip install twine
       - run:
           name: Verify git tag vs. version
           command: |
@@ -38,19 +64,3 @@ jobs:
           name: Upload to pypi
           command: |
             twine upload dist/*
-workflows:
-  version: 2
-  build_and_deploy:
-    jobs:
-      - build:
-          filters:
-            tags:
-              only: /.*/
-      - deploy:
-          requires:
-            - build
-          filters:
-            tags:
-              only: /[0-9]+(\.[0-9]+)*/
-            branches:
-              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,4 +22,6 @@ jobs:
       - run:
           name: Test coverage
           command: |
+            coverage combine
+            coverage xml
             codecov -e TOXENV

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Post office django client
 
-[![image](https://circleci.com/gh/mercadona/postoffice_django/tree/master.svg?style=svg)](https://circleci.com/gh/mercadona/postoffice_django/tree/master)
-
-[![image](https://badge.fury.io/py/postoffice-django.svg)](https://badge.fury.io/py/postoffice-django)
+[![image](https://circleci.com/gh/mercadona/postoffice_django/tree/master.svg?style=svg)](https://circleci.com/gh/mercadona/postoffice_django/tree/master) [![image](https://badge.fury.io/py/postoffice-django.svg)](https://badge.fury.io/py/postoffice-django)
 
 ## What is post office django
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,13 +1,12 @@
 -r base.txt
 
-flake8>=2.1.0
-pytest>=4.6.0
-coverage>=4.4.0
-pytest-cov>=2.7.0
+flake8==3.7.9
+pytest==5.3.5
+coverage==4.5.4
+pytest-cov==2.8.1
 pytest-django==3.8.0
-codecov>=2.0.0
+codecov==2.0.15
 pytest-sugar==0.9.2
 responses==0.10.9
 pytest-responses==0.4.0
 freezegun==0.3.14
-tox==3.14.3

--- a/runtests.py
+++ b/runtests.py
@@ -24,7 +24,7 @@ class PytestTestRunner(object):
         """
         import pytest
 
-        argv = ['-cov-report=xml', '--cov=post_office', 'tests/']
+        argv = ['--cov-report=xml', '--cov=post_office', 'tests/']
         if self.verbosity == 0:
             argv.append('--quiet')
         if self.verbosity == 2:

--- a/runtests.py
+++ b/runtests.py
@@ -24,7 +24,7 @@ class PytestTestRunner(object):
         """
         import pytest
 
-        argv = ['-cov-report=xml', '--cov=post_office' 'tests/']
+        argv = ['-cov-report=xml', '--cov=post_office', 'tests/']
         if self.verbosity == 0:
             argv.append('--quiet')
         if self.verbosity == 2:

--- a/runtests.py
+++ b/runtests.py
@@ -24,7 +24,7 @@ class PytestTestRunner(object):
         """
         import pytest
 
-        argv = ['--cov-report=xml', '--cov=post_office', '--cov-append', 'tests/']
+        argv = []
         if self.verbosity == 0:
             argv.append('--quiet')
         if self.verbosity == 2:

--- a/runtests.py
+++ b/runtests.py
@@ -24,7 +24,7 @@ class PytestTestRunner(object):
         """
         import pytest
 
-        argv = []
+        argv = ['-cov-report=xml', '--cov=post_office' 'tests/']
         if self.verbosity == 0:
             argv.append('--quiet')
         if self.verbosity == 2:

--- a/runtests.py
+++ b/runtests.py
@@ -24,7 +24,7 @@ class PytestTestRunner(object):
         """
         import pytest
 
-        argv = ['--cov-report=xml', '--cov=post_office', 'tests/']
+        argv = ['--cov-report=xml', '--cov=post_office', '--cov-append', 'tests/']
         if self.verbosity == 0:
             argv.append('--quiet')
         if self.verbosity == 2:

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,9 @@
 import os
+import sys
 from os import path
 
 from setuptools import find_packages, setup
+from setuptools.command.install import install
 
 README = open(os.path.join(os.path.dirname(__file__), 'README.md')).read()
 
@@ -9,12 +11,28 @@ README = open(os.path.join(os.path.dirname(__file__), 'README.md')).read()
 os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 current_directory = path.abspath(path.dirname(__file__))
+
 with open(path.join(current_directory, 'README.md'), encoding='utf-8') as file:
     long_description = file.read()
 
+
+VERSION = '0.4.0'
+
+
+class VerifyVersionCommand(install):
+    description = 'Verify that the git tag matches our version'
+
+    def run(self):
+        tag = os.getenv('CIRCLE_TAG')
+
+        if tag != VERSION:
+            info = f"Git tag: {tag} does not match the version of this app: {VERSION}"
+            sys.exit(info)
+
+
 setup(
     name='postoffice_django',
-    version='0.4.0',
+    version=VERSION,
     packages=find_packages(exclude=("tests",)),
     include_package_data=True,
     license='APACHE License',
@@ -37,4 +55,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
     ],
+    cmdclass={
+        'verify': VerifyVersionCommand,
+    }
 )

--- a/tox.ini
+++ b/tox.ini
@@ -14,3 +14,15 @@ deps =
 passenv = TOXENV CODECOV_*
 commands =
     python runtests.py
+
+[testenv:clean]
+deps = coverage
+skip_install = true
+commands = coverage erase
+
+[testenv:report]
+deps = coverage
+skip_install = true
+commands =
+    coverage report
+    coverage xml

--- a/tox.ini
+++ b/tox.ini
@@ -14,5 +14,3 @@ deps =
 passenv = TOXENV CODECOV_*
 commands =
     python runtests.py
-    coverage combine
-    coverage xml

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,9 @@
 [tox]
 envlist =
+    clean,
 	py37-django{21,22,30},
     py38-django{21,22,30},
+    report,
 	flake8
 
 [testenv]
@@ -11,6 +13,9 @@ setenv =
 	PYTHONWARNINGS = once
 deps =
     -r ./requirements/test.txt
+depends =
+    {py37-django{21,22,30},py38-django{21,22,30}}: clean
+    report: py37-django{21,22,30},py38-django{21,22,30}
 passenv = TOXENV CODECOV_*
 commands =
     python runtests.py

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,7 @@
 [tox]
 envlist =
-    clean,
 	py37-django{21,22,30},
     py38-django{21,22,30},
-    report,
 	flake8
 
 [testenv]
@@ -13,21 +11,6 @@ setenv =
 	PYTHONWARNINGS = once
 deps =
     -r ./requirements/test.txt
-depends =
-    {py37-django{21,22,30},py38-django{21,22,30}}: clean
-    report: py37-django{21,22,30},py38-django{21,22,30}
 passenv = TOXENV CODECOV_*
 commands =
     python runtests.py
-
-[testenv:clean]
-deps = coverage
-skip_install = true
-commands = coverage erase
-
-[testenv:report]
-deps = coverage
-skip_install = true
-commands =
-    coverage report
-    coverage xml

--- a/tox.ini
+++ b/tox.ini
@@ -14,4 +14,5 @@ deps =
 passenv = TOXENV CODECOV_*
 commands =
     python runtests.py
-    codecov -e TOXENV
+    coverage combine
+    coverage xml

--- a/tox.ini
+++ b/tox.ini
@@ -5,10 +5,13 @@ envlist =
 	flake8
 
 [testenv]
-commands = python runtests.py
 setenv =
 	DJANGO_SETTINGS_MODULE = tests.settings
 	PYTHONPATH = {toxinidir}
 	PYTHONWARNINGS = once
 deps =
     -r ./requirements/test.txt
+passenv = TOXENV CODECOV_*
+commands =
+    python runtests.py
+    codecov -e TOXENV


### PR DESCRIPTION
Resolves #15 

- Build package and upload to PyPi on git tags

`VERSION` constant must match the git tag in order to deliver successfully. 