### PR TITLE
Store correct error message

### DIFF
--- a/postoffice_django/publishing.py
+++ b/postoffice_django/publishing.py
@@ -44,8 +44,8 @@ def _save_publishing_error(response: Response, message: dict) -> None:
     if response.status_code == 500:
         error = 'Internal server error'
 
-    if response.status_code == 422:
-        error = response.json().get('errors').get('detail')
+    if response.status_code == 400:
+        error = response.json().get('data').get('errors')
 
     _create_publishing_error(message, error)
 


### PR DESCRIPTION
- Save correct errors messages from postoffice

As the errors field is only to view the erros on admin page, I think we shouldn't change the field to JSONField or parse the errors in another way.

Resolves #23 