### PR TITLE
Catch Timeout exception when publishing

### DIFF
--- a/postoffice_django/publishing.py
+++ b/postoffice_django/publishing.py
@@ -1,6 +1,6 @@
 import requests
 from requests import Response
-from requests.exceptions import ConnectionError, ConnectTimeout
+from requests.exceptions import ConnectionError, Timeout
 
 from . import settings
 from .models import PublishingError
@@ -21,7 +21,7 @@ def publish(topic: str, payload: dict, **attrs: dict) -> None:
                                  json=message,
                                  timeout=settings.get_timeout()
                                  )
-    except (ConnectTimeout, ConnectionError):
+    except (ConnectionError, Timeout):
         _save_connection_not_established(message)
         return
 

--- a/tests/test_publishing.py
+++ b/tests/test_publishing.py
@@ -136,7 +136,7 @@ class TestPublishing:
     @patch('postoffice_django.publishing.requests.post')
     def test_save_publishing_error_when_postoffice_raises_timeout(
             self, post_mock):
-        post_mock.side_effect = requests.exceptions.ConnectTimeout()
+        post_mock.side_effect = requests.exceptions.Timeout()
 
         publish(topic='some_topic', payload='some_payload', hive='vlc1')
 


### PR DESCRIPTION
Start catching `Timeout`, so we'll catch both `ConnectTimeout` and `ReadTimeout`