### PR TITLE
Add fields to admin list display

### DIFF
--- a/postoffice_django/admin.py
+++ b/postoffice_django/admin.py
@@ -6,6 +6,8 @@ from .models import PublishingError
 @admin.register(PublishingError)
 class PublishingErrorAdmin(admin.ModelAdmin):
 
+    list_display = ['topic', 'error', 'created_at']
+
     def has_add_permission(self, request, obj=None):
         return False
 


### PR DESCRIPTION
Show useful information on admin's list display:
- topic
- error
- created_at

Resolves #33 