### PR TITLE
No throw exception when topic or publisher already exists

### DIFF
--- a/postoffice_django/config.py
+++ b/postoffice_django/config.py
@@ -1,26 +1,24 @@
 import logging
-import requests
+from collections import namedtuple
 from http import HTTPStatus
 
+import requests
 from django.urls import reverse
+from requests.exceptions import ConnectionError, ConnectTimeout
+
+from postoffice_django.exceptions import BadPublisherCreation, BadTopicCreation
 
 from . import settings
 
-from postoffice_django.exceptions import (
-    BadPublisherCreation,
-    BadTopicCreation
-)
-from requests.exceptions import ConnectTimeout, ConnectionError
-
-
 logger = logging.getLogger(__name__)
 
+ConfigurationResponse = namedtuple('ConfigurationResponse', ['report_error'])
 
 def configure_publishers() -> None:
     uncreated_publishers = []
 
     for consumer in settings.get_consumers():
-        if not _create_publishers(consumer):
+        if _create_publishers(consumer).report_error:
             uncreated_publishers.append(consumer)
 
     if uncreated_publishers:
@@ -31,7 +29,7 @@ def configure_topics() -> None:
     uncreated_topics = []
 
     for topic in settings.get_topics():
-        if not _create_topic(topic):
+        if _create_topic(topic).report_error:
             uncreated_topics.append(topic)
 
     if uncreated_topics:
@@ -62,7 +60,7 @@ def _generate_origin_host() -> str:
     return settings.get_origin_host() + reverse('postoffice-messages-list')
 
 
-def _execute_request(url: str, payload: dict):
+def _execute_request(url: str, payload: dict) -> bool:
     try:
         response = requests.post(
             url,
@@ -70,6 +68,9 @@ def _execute_request(url: str, payload: dict):
             timeout=settings.get_timeout()
         )
     except (ConnectTimeout, ConnectionError):
-        return False
+        return ConfigurationResponse(report_error=True)
 
-    return response.status_code == HTTPStatus.CREATED
+    if response.status_code == HTTPStatus.CREATED or response.status_code == HTTPStatus.CONFLICT:
+        return ConfigurationResponse(report_error=False)
+
+    return ConfigurationResponse(report_error=True)

--- a/postoffice_django/config.py
+++ b/postoffice_django/config.py
@@ -70,7 +70,11 @@ def _execute_request(url: str, payload: dict) -> bool:
     except (ConnectTimeout, ConnectionError):
         return ConfigurationResponse(report_error=True)
 
-    if response.status_code == HTTPStatus.CREATED or response.status_code == HTTPStatus.CONFLICT:
+    if response.status_code == HTTPStatus.CONFLICT:
+        logger.warning('Existing resource', extra={'url': url, 'payload': payload})
+        return ConfigurationResponse(report_error=False)
+
+    if response.status_code == HTTPStatus.CREATED:
         return ConfigurationResponse(report_error=False)
 
     return ConfigurationResponse(report_error=True)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -76,6 +76,16 @@ class TestConfigurePublishers:
         with pytest.raises(BadPublisherCreation):
             configure_publishers()
 
+    def test_do_not_raise_exception_when_publisher_already_exists(
+            self, publisher_already_exists):
+        responses.add(responses.POST,
+                      self.POSTOFFICE_PUBLISHER_CREATION_URL,
+                      status=409,
+                      body=publisher_already_exists,
+                      content_type='application/json')
+
+        configure_publishers()
+
     @patch('postoffice_django.config.requests.post')
     def test_raise_exception_when_postoffice_raises_timeout(
             self, post_mock):
@@ -238,5 +248,3 @@ class TestConfigureTopics:
                       content_type='application/json')
 
         configure_topics()
-
-        assert True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -204,3 +204,14 @@ class TestConfigureTopics:
             'name': 'another_topic_to_be_created',
             'origin_host': 'example.com/messages/'
         }
+
+    def test_do_not_raise_exception_when_topic_already_exists(self, topic_already_exists):
+        responses.add(responses.POST,
+                      self.POSTOFFICE_TOPIC_CREATION_URL,
+                      status=409,
+                      body=topic_already_exists,
+                      content_type='application/json')
+
+        configure_topics()
+
+        assert True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -88,7 +88,7 @@ class TestConfigurePublishers:
         configure_publishers()
 
         assert (
-            'postoffice_django.settings',
+            'postoffice_django.config',
             logging.WARNING,
             'Existing resource'
         ) in caplog.record_tuples
@@ -258,7 +258,7 @@ class TestConfigureTopics:
         configure_topics()
 
         assert (
-            'postoffice_django.settings',
+            'postoffice_django.config',
             logging.WARNING,
             'Existing resource'
         ) in caplog.record_tuples

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -25,6 +25,19 @@ class TestConfigurePublishers:
                 }
             }
         })
+
+    @pytest.fixture
+    def publisher_with_validation_error(self):
+        return json.dumps({
+            'data': {
+                'errors': {
+                    'target': [
+                        'This field is required'
+                    ]
+                }
+            }
+        })
+
     POSTOFFICE_PUBLISHER_CREATION_URL = f'{POSTOFFICE_URL}/api/publishers/'
 
     def test_request_body_sent_to_create_publishers(self):
@@ -53,11 +66,11 @@ class TestConfigurePublishers:
         }
 
     def test_raise_exception_when_can_not_create_publisher(
-            self, publisher_already_exists):
+            self, publisher_with_validation_error):
         responses.add(responses.POST,
                       self.POSTOFFICE_PUBLISHER_CREATION_URL,
                       status=400,
-                      body=publisher_already_exists,
+                      body=publisher_with_validation_error,
                       content_type='application/json')
 
         with pytest.raises(BadPublisherCreation):
@@ -80,11 +93,11 @@ class TestConfigurePublishers:
             configure_publishers()
 
     def test_try_create_all_publishers_when_some_publisher_fails(
-            self, publisher_already_exists):
+            self, publisher_with_validation_error):
         responses.add(responses.POST,
                       self.POSTOFFICE_PUBLISHER_CREATION_URL,
                       status=400,
-                      body=publisher_already_exists,
+                      body=publisher_with_validation_error,
                       content_type='application/json')
         responses.add(responses.POST,
                       self.POSTOFFICE_PUBLISHER_CREATION_URL,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -132,6 +132,18 @@ class TestConfigureTopics:
             }
         })
 
+    @pytest.fixture
+    def topic_with_error_validation(self):
+        return json.dumps({
+            'data': {
+                'errors': {
+                    'name': [
+                        'This field is required'
+                    ]
+                }
+            }
+        })
+
     def test_request_body_sent_to_create_topic(self):
         responses.add(responses.POST,
                       self.POSTOFFICE_TOPIC_CREATION_URL,
@@ -152,11 +164,11 @@ class TestConfigureTopics:
         }
 
     def test_raise_exception_when_can_not_create_topics(
-            self, topic_already_exists):
+            self, topic_with_error_validation):
         responses.add(responses.POST,
                       self.POSTOFFICE_TOPIC_CREATION_URL,
                       status=400,
-                      body=topic_already_exists,
+                      body=topic_with_error_validation,
                       content_type='application/json')
 
         with pytest.raises(BadTopicCreation):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from unittest.mock import patch
 
 import pytest
@@ -77,7 +78,7 @@ class TestConfigurePublishers:
             configure_publishers()
 
     def test_do_not_raise_exception_when_publisher_already_exists(
-            self, publisher_already_exists):
+            self, publisher_already_exists, caplog):
         responses.add(responses.POST,
                       self.POSTOFFICE_PUBLISHER_CREATION_URL,
                       status=409,
@@ -85,6 +86,12 @@ class TestConfigurePublishers:
                       content_type='application/json')
 
         configure_publishers()
+
+        assert (
+            'postoffice_django.settings',
+            logging.WARNING,
+            'Existing resource'
+        ) in caplog.record_tuples
 
     @patch('postoffice_django.config.requests.post')
     def test_raise_exception_when_postoffice_raises_timeout(
@@ -240,7 +247,8 @@ class TestConfigureTopics:
             'origin_host': 'example.com/messages/'
         }
 
-    def test_do_not_raise_exception_when_topic_already_exists(self, topic_already_exists):
+    def test_do_not_raise_exception_when_topic_already_exists(
+            self, topic_already_exists, caplog):
         responses.add(responses.POST,
                       self.POSTOFFICE_TOPIC_CREATION_URL,
                       status=409,
@@ -248,3 +256,9 @@ class TestConfigureTopics:
                       content_type='application/json')
 
         configure_topics()
+
+        assert (
+            'postoffice_django.settings',
+            logging.WARNING,
+            'Existing resource'
+        ) in caplog.record_tuples


### PR DESCRIPTION
When we create a topic that already exists, instead of throw exception, we go to log the failed creation.

As the refactor is for to both (topic and publisher) and is very easy, i joined the two behaviour (do not raise exception when topic exists and do not raise exception when publisher exists) in only one PR