### PR TITLE
Be able to send timeout when creating publishers

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ POSTOFFICE = {
             'from_now': False
         }],
     'TIMEOUT': 0.3,
+    'BULK_TIMEOUT': 5,
     'ORIGIN_HOST': 'example.com',
     'TOPICS': ['topic_to_create', 'another_topic_to_create']
 }
@@ -82,7 +83,11 @@ POSTOFFICE = {
 
     - `type`: http/pubsub
     
+    - `timeout`: Seconds Postoffice should wait before cancelling the request. [Optional] 
+    
 - `TIMEOUT`: Specific timeout to use in every communication with Postoffice. If not specified, the default value is 0.5 seconds.
+
+- `BULK_TIMEOUT`: Specific timeout to use when sending bulk messages to Postoffice. If not specified, the default value is 5 seconds.
 
 - `ORIGIN_HOST`: The host from where the topic is created (your host).  It is necessary in order to `postoffice` know where the topic come from.
 

--- a/postoffice_django/config.py
+++ b/postoffice_django/config.py
@@ -37,7 +37,7 @@ def configure_topics() -> None:
         raise BadTopicCreation(uncreated_topics)
 
 
-def _create_publishers(consumer: dict) -> None:
+def _create_publishers(consumer: dict) -> ConfigurationResponse:
     url = f'{settings.get_url()}/api/publishers/'
     payload = {
         'active': True,
@@ -47,10 +47,18 @@ def _create_publishers(consumer: dict) -> None:
         'from_now': True
     }
 
+    payload.update(_get_publisher_timeout(consumer))
+
     return _execute_request(url, payload)
 
 
-def _create_topic(topic_name: str) -> None:
+def _get_publisher_timeout(consumer: dict) -> dict:
+    if not consumer.get('timeout'):
+        return {}
+    return {'seconds_timeout': consumer.get('timeout')}
+
+
+def _create_topic(topic_name: str) -> ConfigurationResponse:
     url = f'{settings.get_url()}/api/topics/'
     payload = {'name': topic_name, 'origin_host': _generate_origin_host()}
 
@@ -61,7 +69,7 @@ def _generate_origin_host() -> str:
     return settings.get_origin_host() + reverse('postoffice-messages-list')
 
 
-def _execute_request(url: str, payload: dict) -> bool:
+def _execute_request(url: str, payload: dict) -> ConfigurationResponse:
     try:
         response = requests.post(
             url,

--- a/postoffice_django/publishing.py
+++ b/postoffice_django/publishing.py
@@ -85,13 +85,6 @@ class BulkPublisher(Publisher):
     def __init__(self, topic, payload, **attributes):
         super().__init__(topic=topic, payload=payload, bulk=True, **attributes)
 
-    def _create_message(self) -> dict:
-        return {
-            'topic': self.topic,
-            'payload': self.payload,
-            'attributes': self._stringify_attributes()
-        }
-
     def _create_publishing_error(self, error: str) -> None:
         PublishingError.objects.create(
             topic=self.topic,
@@ -103,9 +96,9 @@ class BulkPublisher(Publisher):
 
     def _create_failed_message(self) -> list:
         return [{
-           'topic': self.topic,
-           'attributes': self.attributes,
-           'payload': message_payload
+            'topic': self.topic,
+            'attributes': self.attributes,
+            'payload': message_payload
         } for message_payload in self.payload]
 
     def _error_payload(self):

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -35,6 +35,7 @@ POSTOFFICE = {
             'topic': 'some_topic',
             'target': 'http://www.some_url.com',
             'type': 'http',
+            'timeout': 20,
             'from_now': True
         },
         {

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -56,6 +56,7 @@ class TestConfigurePublishers:
             'target': 'http://www.some_url.com',
             'topic': 'some_topic',
             'type': 'http',
+            'seconds_timeout': 20,
             'from_now': True
         }
         assert json.loads(responses.calls[1].request.body) == {
@@ -127,7 +128,7 @@ class TestConfigurePublishers:
             configure_publishers()
 
         assert bad_publisher_creation_exception.value.message == (
-            'Can not create publisher. Publisher not created: [{\'topic\': \'some_topic\', \'target\': \'http://www.some_url.com\', \'type\': \'http\', \'from_now\': True}]'  # noqa
+            'Can not create publisher. Publisher not created: [{\'topic\': \'some_topic\', \'target\': \'http://www.some_url.com\', \'type\': \'http\', \'timeout\': 20, \'from_now\': True}]'  # noqa
         )
         assert len(responses.calls) == 2
         assert json.loads(responses.calls[0].request.body) == {
@@ -135,6 +136,7 @@ class TestConfigurePublishers:
             'target': 'http://www.some_url.com',
             'topic': 'some_topic',
             'type': 'http',
+            'seconds_timeout': 20,
             'from_now': True
         }
         assert json.loads(responses.calls[1].request.body) == {


### PR DESCRIPTION
In some cases we might want to configure the timeout once per publisher, so we don't need to change it in the UI later on. 