### PR TITLE
Make PostOffice_Django able to parse `datetimes` to `JSON`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @lonamiaec @jjponz @elreplicante @sanntt @xavierparedesruiz
+*       @lonamiaec @jjponz @elreplicante @sanntt @xavierparedesruiz @RicardoFernandez @chisvi

--- a/postoffice_django/publishing.py
+++ b/postoffice_django/publishing.py
@@ -1,4 +1,7 @@
+import json
+
 import requests
+from django.core.serializers.json import DjangoJSONEncoder
 from requests import Response
 from requests.exceptions import ConnectionError, Timeout
 
@@ -31,8 +34,9 @@ class Publisher:
 
     def publish(self):
         try:
+            message = json.dumps(self.message, cls=DjangoJSONEncoder)
             response = requests.post(
-                self.url, json=self.message, timeout=self.timeout)
+                self.url, data=message, headers={'Content-Type': 'application/json'}, timeout=self.timeout)
         except (ConnectionError, Timeout):
             self._save_connection_not_established()
             return


### PR DESCRIPTION
## What?
<!--- Describe your changes in detail -->
Now we use the encoder from Django in the `publish` method.
With this change we can publish several new types like `datetime`, `Decimal` and `Promise`.
Look at this doc if you wish to know more --> https://docs.djangoproject.com/en/3.0/topics/serialization/#djangojsonencoder

## Why?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We were trying to publish payloads with dynamic properties and we couldn't infer the type of those properties.
Since we already found a problem with `datetime` type that didn't exist using `Rele` we decided to upgrade `postoffice_django` to work around this problem.

## Example

With those changes, we can do things like this:

```python
 from postoffice_django import publishing
 from datetime import datetime

 publishing.publish(
	topic='picking-event-created',
	payload={'name':'random-name', 'occurred_at':datetime.now()},
 	hive_code= 'vlc1'
)

```
