### PR TITLE
Stringify attributes in init

### DIFF
--- a/postoffice_django/publishing.py
+++ b/postoffice_django/publishing.py
@@ -27,7 +27,7 @@ class Publisher:
         self.url = f'{settings.get_url()}/{self.URL}'
         self.topic = topic
         self.payload = payload
-        self.attributes = attributes
+        self.attributes = self._stringify(attributes)
         self.timeout = self.TIMEOUT
         self.bulk = bulk
         self.message = self._create_message()
@@ -48,11 +48,10 @@ class Publisher:
         return {
             'topic': self.topic,
             'payload': self.payload,
-            'attributes': self._stringify_attributes()
+            'attributes': self.attributes,
         }
 
-    def _stringify_attributes(self) -> dict:
-        attributes = self.attributes
+    def _stringify(self, attributes) -> dict:
         return {key: str(attributes[key]) for key in attributes.keys()}
 
     def _save_connection_not_established(self) -> None:

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open(path.join(current_directory, 'README.md'), encoding='utf-8') as file:
     long_description = file.read()
 
 
-VERSION = '0.7.1'
+VERSION = '0.7.2'
 
 
 class VerifyVersionCommand(install):

--- a/tests/test_publishing.py
+++ b/tests/test_publishing.py
@@ -110,7 +110,8 @@ class TestPublishing:
                       body=json.dumps(''),
                       content_type='application/json')
 
-        publish(topic='some_topic', payload='some_payload', hive='vlc1')
+        publish(topic='some_topic', payload='some_payload',
+                hive='vlc1', published_at=12345.0)
 
         publishing_error = PublishingError.objects.first()
         assert PublishingError.objects.count() == 1
@@ -118,6 +119,9 @@ class TestPublishing:
         assert publishing_error.created_at == datetime.datetime(
             2019, 6, 19, 18, 59, 59, tzinfo=pytz.UTC)
         assert not publishing_error.bulk
+        assert publishing_error.payload == 'some_payload'
+        assert publishing_error.attributes == {
+            'hive': 'vlc1', 'published_at': '12345.0'}
 
     @freeze_time('2019-06-19 20:59:59+02:00')
     def test_save_publishing_error_when_service_returns_400(


### PR DESCRIPTION
Non-string attributes were converted when posting the message to PostOffice, but when saving it in PublishingError, they were stored with the original data type, which made PostOffice not like it. 