### PR TITLE
Add DjangoJSONEncoder encoder to the json fields of the PublishingError model

### DIFF
--- a/postoffice_django/migrations/0003_set_json_encoder.py
+++ b/postoffice_django/migrations/0003_set_json_encoder.py
@@ -1,0 +1,26 @@
+import django.core.serializers.json
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('postoffice_django', '0002_add_bulk_field'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='publishingerror',
+            name='payload',
+            field=django.db.models.JSONField(
+                encoder=django.core.serializers.json.DjangoJSONEncoder),
+        ),
+        migrations.AlterField(
+            model_name='publishingerror',
+            name='attributes',
+            field=django.db.models.JSONField(
+                encoder=django.core.serializers.json.DjangoJSONEncoder,
+                null=True
+            ),
+        ),
+    ]

--- a/postoffice_django/models.py
+++ b/postoffice_django/models.py
@@ -1,11 +1,12 @@
 from django.contrib.postgres.fields import JSONField
+from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
 
 
 class PublishingError(models.Model):
     topic = models.CharField(max_length=100)
-    payload = JSONField()
-    attributes = JSONField(null=True)
+    payload = JSONField(encoder=DjangoJSONEncoder)
+    attributes = JSONField(null=True, encoder=DjangoJSONEncoder)
     bulk = models.BooleanField(default=False)
     error = models.CharField(max_length=255, default='')
     created_at = models.DateTimeField(auto_now_add=True)

--- a/postoffice_django/models.py
+++ b/postoffice_django/models.py
@@ -1,6 +1,6 @@
-from django.contrib.postgres.fields import JSONField
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
+from django.db.models import JSONField
 
 
 class PublishingError(models.Model):

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open(path.join(current_directory, 'README.md'), encoding='utf-8') as file:
     long_description = file.read()
 
 
-VERSION = '0.8.2'
+VERSION = '0.9.0'
 
 
 class VerifyVersionCommand(install):


### PR DESCRIPTION
## WHAT
#60 
Modify  `PublishingError` model to use the `DjangoJSONEncoder` as encoder for fields `payload` and `attributes`.

Also updated the django.db.models.JSONField following warning messages recommendations:
```
postoffice_django.PublishingError.attributes: (fields.W904) django.contrib.postgres.fields.JSONField is deprecated. Support for it (except in historical migrations) will be removed in Django 4.0.
        HINT: Use django.db.models.JSONField instead.
```

## WHY
When an error occurred publishing, if either the payload or the attributes contained a datetime, `PublishingError` creation would fail.
https://sentry.prod.monline/mdona-production/dispatch-api/issues/15595/?query=is%3Aunresolved

