### PR TITLE
Do not raise BadPublisherCreation nor BadTopicCreation, log as an error instead

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @lonamiaec @jjponz @elreplicante @sanntt @xavierparedesruiz @RicardoFernandez @chisvi
+*       @lonamiaec @jjponz @elreplicante @sanntt @xavierparedesruiz @RicardoFernandez @chisvi @perizote

--- a/postoffice_django/config.py
+++ b/postoffice_django/config.py
@@ -6,8 +6,6 @@ import requests
 from django.urls import reverse
 from requests.exceptions import ConnectionError, ConnectTimeout
 
-from postoffice_django.exceptions import BadPublisherCreation, BadTopicCreation
-
 from . import settings
 
 logger = logging.getLogger(__name__)

--- a/postoffice_django/config.py
+++ b/postoffice_django/config.py
@@ -36,7 +36,9 @@ def configure_topics() -> None:
             uncreated_topics.append(topic)
 
     if uncreated_topics:
-        raise BadTopicCreation(uncreated_topics)
+        logger.warning('Topic cannot be created',
+                       extra={'uncreated_topics': uncreated_topics})
+        return ConfigurationResponse(report_error=False)
 
 
 def _create_publishers(consumer: dict) -> ConfigurationResponse:

--- a/postoffice_django/config.py
+++ b/postoffice_django/config.py
@@ -25,7 +25,6 @@ def configure_publishers() -> None:
     if uncreated_publishers:
         logger.warning('Publisher cannot be created',
                        extra={'uncreated_publishers': uncreated_publishers})
-        return ConfigurationResponse(report_error=False)
 
 
 def configure_topics() -> None:
@@ -38,7 +37,6 @@ def configure_topics() -> None:
     if uncreated_topics:
         logger.warning('Topic cannot be created',
                        extra={'uncreated_topics': uncreated_topics})
-        return ConfigurationResponse(report_error=False)
 
 
 def _create_publishers(consumer: dict) -> ConfigurationResponse:

--- a/postoffice_django/config.py
+++ b/postoffice_django/config.py
@@ -23,7 +23,9 @@ def configure_publishers() -> None:
             uncreated_publishers.append(consumer)
 
     if uncreated_publishers:
-        raise BadPublisherCreation(uncreated_publishers)
+        logger.warning('Publisher cannot be created',
+                       extra={'uncreated_publishers': uncreated_publishers})
+        return ConfigurationResponse(report_error=False)
 
 
 def configure_topics() -> None:

--- a/postoffice_django/config.py
+++ b/postoffice_django/config.py
@@ -23,8 +23,8 @@ def configure_publishers() -> None:
             uncreated_publishers.append(consumer)
 
     if uncreated_publishers:
-        logger.warning('Publisher cannot be created',
-                       extra={'uncreated_publishers': uncreated_publishers})
+        logger.error('Publisher cannot be created',
+                     extra={'uncreated_publishers': uncreated_publishers})
 
 
 def configure_topics() -> None:
@@ -35,8 +35,8 @@ def configure_topics() -> None:
             uncreated_topics.append(topic)
 
     if uncreated_topics:
-        logger.warning('Topic cannot be created',
-                       extra={'uncreated_topics': uncreated_topics})
+        logger.error('Topic cannot be created',
+                     extra={'uncreated_topics': uncreated_topics})
 
 
 def _create_publishers(consumer: dict) -> ConfigurationResponse:

--- a/postoffice_django/exceptions.py
+++ b/postoffice_django/exceptions.py
@@ -6,15 +6,3 @@ class UrlSettingNotDefined(Exception):
 class OriginHostSettingNotDefined(Exception):
     def __init__(self):
         self.message = 'ORIGIN_HOST is not defined on settings'
-
-
-class BadTopicCreation(Exception):
-    def __init__(self, topic_name):
-        self.message = (
-            f'Can not create topic. Topic no created: { topic_name }')
-
-
-class BadPublisherCreation(Exception):
-    def __init__(self, publisher):
-        self.message = (
-            f'Can not create publisher. Publisher not created: { publisher }')

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -126,7 +126,7 @@ class TestConfigurePublishers:
             'Publisher cannot be created'
         ) in caplog.record_tuples
 
-    def test_do_not_try_create_all_publishers_when_some_publisher_fails(
+    def test_try_create_all_publishers_when_some_publisher_fails(
             self, publisher_with_validation_error, caplog):
         responses.add(responses.POST,
                       self.POSTOFFICE_PUBLISHER_CREATION_URL,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -80,7 +80,7 @@ class TestConfigurePublishers:
 
         assert (
             'postoffice_django.config',
-            logging.WARNING,
+            logging.ERROR,
             'Publisher cannot be created'
         ) in caplog.record_tuples
 
@@ -109,7 +109,7 @@ class TestConfigurePublishers:
 
         assert (
             'postoffice_django.config',
-            logging.WARNING,
+            logging.ERROR,
             'Publisher cannot be created'
         ) in caplog.record_tuples
 
@@ -122,7 +122,7 @@ class TestConfigurePublishers:
 
         assert (
             'postoffice_django.config',
-            logging.WARNING,
+            logging.ERROR,
             'Publisher cannot be created'
         ) in caplog.record_tuples
 
@@ -143,7 +143,7 @@ class TestConfigurePublishers:
 
         assert (
             'postoffice_django.config',
-            logging.WARNING,
+            logging.ERROR,
             'Publisher cannot be created'
         ) in caplog.record_tuples
 
@@ -225,7 +225,7 @@ class TestConfigureTopics:
 
         assert (
             'postoffice_django.config',
-            logging.WARNING,
+            logging.ERROR,
             'Topic cannot be created'
         ) in caplog.record_tuples
 
@@ -238,7 +238,7 @@ class TestConfigureTopics:
 
         assert (
             'postoffice_django.config',
-            logging.WARNING,
+            logging.ERROR,
             'Topic cannot be created'
         ) in caplog.record_tuples
 
@@ -251,7 +251,7 @@ class TestConfigureTopics:
 
         assert (
             'postoffice_django.config',
-            logging.WARNING,
+            logging.ERROR,
             'Topic cannot be created'
         ) in caplog.record_tuples
 
@@ -272,7 +272,7 @@ class TestConfigureTopics:
 
         assert (
             'postoffice_django.config',
-            logging.WARNING,
+            logging.ERROR,
             'Topic cannot be created'
         ) in caplog.record_tuples
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,7 +8,6 @@ import responses
 from django.conf import settings
 
 from postoffice_django.config import configure_publishers, configure_topics
-from postoffice_django.exceptions import BadPublisherCreation, BadTopicCreation
 
 POSTOFFICE_URL = settings.POSTOFFICE['URL']
 


### PR DESCRIPTION
So that we are aware that there's an error creating a publisher or a topic, but it doesn't block a release. Furthermore, we were facing this block in Picking e2e since we create publishers for a topic that we aren't the owners, and so, it doesn't exist.