### PR TITLE
Bump version from 0.9.0 to 0.10.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open(path.join(current_directory, 'README.md'), encoding='utf-8') as file:
     long_description = file.read()
 
 
-VERSION = '0.19.0'
+VERSION = '0.10.0'
 
 
 class VerifyVersionCommand(install):

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open(path.join(current_directory, 'README.md'), encoding='utf-8') as file:
     long_description = file.read()
 
 
-VERSION = '0.9.0'
+VERSION = '0.19.0'
 
 
 class VerifyVersionCommand(install):


### PR DESCRIPTION
Last released version is 0.18.1 and we just wanted to release a new one as 0.19.0, but it failed because tag and version didn't match