### PR TITLE
Add missing migration to make `id` field of  `PublishingError` a `BigAutoField`

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ This will be handled on Postoffices and we'll actually receive two messages for 
 
 ### Implement
 
-1. `make install-test-requirements`
+1. `make install-test-dependencies`
 1. `make env-start`
 1. Write a test.
 1. `make test`

--- a/postoffice_django/migrations/0004_alter_id_to_bigautofield.py
+++ b/postoffice_django/migrations/0004_alter_id_to_bigautofield.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('postoffice_django', '0003_set_json_encoder'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='publishingerror',
+            name='id',
+            field=models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID'),
+        ),
+    ]


### PR DESCRIPTION
Prior to `django` 3.2, auto-created primary key fields were always [AutoField](https://docs.djangoproject.com/en/4.0/ref/models/fields/#django.db.models.AutoField)s, however, starting with version 3.2, they are created as 