### PR TITLE
[Added] Add RECOVERY_ENABLED option

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ POSTOFFICE = {
     'TIMEOUT': 0.3,
     'BULK_TIMEOUT': 5,
     'ORIGIN_HOST': 'example.com',
-    'TOPICS': ['topic_to_create', 'another_topic_to_create']
+    'TOPICS': ['topic_to_create', 'another_topic_to_create'],
+    'RECOVERY_ENABLED': True
 }
 ```
 - `URL`: Is the `url` where the Postoffice server is hosted.
@@ -93,6 +94,7 @@ POSTOFFICE = {
 
 - `TOPICS`: Topics to be created in order to send messages to `postoffice`
 
+- `RECOVERY_ENABLED`: Enables the recovery of failed messages on all new topics. If not specified, the default value is false.
 
 Finally add `postoffice` path in your django urls file:
 

--- a/postoffice_django/config.py
+++ b/postoffice_django/config.py
@@ -70,7 +70,11 @@ def _get_publisher_retry(consumer: dict) -> dict:
 
 def _create_topic(topic_name: str) -> ConfigurationResponse:
     url = f'{settings.get_url()}/api/topics/'
-    payload = {'name': topic_name, 'origin_host': _generate_origin_host()}
+    payload = {
+        'name': topic_name,
+        'origin_host': _generate_origin_host(),
+        'recovery_enabled': settings.get_recovery_enabled()
+    }
 
     return _execute_request(url, payload)
 

--- a/postoffice_django/settings.py
+++ b/postoffice_django/settings.py
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_TIMEOUT = 0.5
 DEFAULT_BULK_TIMEOUT = 5
+DEFAULT_RECOVERY_ENABLED = False
 
 
 def get_url() -> str:
@@ -63,3 +64,7 @@ def get_topics() -> List[str]:
     except KeyError:
         logger.warning('Topics config key is missing')
         return []
+
+
+def get_recovery_enabled() -> bool:
+    return settings.POSTOFFICE.get('RECOVERY_ENABLED', DEFAULT_RECOVERY_ENABLED)

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open(path.join(current_directory, 'README.md'), encoding='utf-8') as file:
     long_description = file.read()
 
 
-VERSION = '0.11.0'
+VERSION = '0.12.0'
 
 
 class VerifyVersionCommand(install):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -11,7 +11,9 @@ from postoffice_django.settings import (
     get_timeout,
     get_topics,
     get_url,
-    get_bulk_timeout)
+    get_bulk_timeout,
+    get_recovery_enabled
+)
 
 
 class TestSettings:
@@ -72,3 +74,16 @@ class TestSettings:
             logging.WARNING,
             'Topics config key is missing'
         ) in caplog.record_tuples
+
+    @pytest.mark.parametrize('defined_value', [True, False])
+    def test_returns_recovery_enabled_value_when_is_defined(
+            self, defined_value, settings):
+        settings.POSTOFFICE['RECOVERY_ENABLED'] = defined_value
+
+        assert get_recovery_enabled() is defined_value
+
+    def test_returns_default_recovery_enabled_value_when_is_not_defined(
+            self, settings):
+        del(settings.POSTOFFICE['RECOVERY_ENABLED'])
+
+        assert get_recovery_enabled() is False


### PR DESCRIPTION
Postoffice Django does not send the value `recovery_enabled` when creating topics, which causes all topics to have this option disabled by default. This can be a big pain because activating it requires accessing the database, manually updating all values and then restarting the workers.

This solution enables users to configure the default value for the `recovery_enabled` param and it will be applied to all topic that are created for this topic.

## ⚠️ WARNING ⚠️ 
This will not be applied to already existing topics.

## ℹ️ INFO ℹ️ 
The `settings_with_recovery_enabled` is implemented that way to ensure the isolation of the setting throughout the other test suites.